### PR TITLE
Fix displaying icons for flatpak system apps

### DIFF
--- a/com.saivert.pwvucontrol.json
+++ b/com.saivert.pwvucontrol.json
@@ -14,8 +14,9 @@
         "--device=dri",
         "--socket=wayland",
         "--filesystem=xdg-run/pipewire-0",
+        "--filesystem=host-os",
         "--filesystem=/var/lib/flatpak:ro",
-        "--env=XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/var/lib/flatpak/exports/share:/run/host/share"
+        "--env=XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/var/lib/flatpak/exports/share:/run/host/usr/local/share:/run/host/share"
     ],
     "build-options": {
         "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm16/bin",

--- a/com.saivert.pwvucontrol.json
+++ b/com.saivert.pwvucontrol.json
@@ -13,7 +13,9 @@
         "--socket=fallback-x11",
         "--device=dri",
         "--socket=wayland",
-        "--filesystem=xdg-run/pipewire-0"
+        "--filesystem=xdg-run/pipewire-0",
+        "--filesystem=/var/lib/flatpak:ro",
+        "--env=XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/var/lib/flatpak/exports/share:/run/host/share"
     ],
     "build-options": {
         "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm16/bin",


### PR DESCRIPTION
Currently there are no icons for any flatpak applications as reported in #3.

With this change at least the flatpak applications installed as **system** and apps installed at `/usr/local` will have icons in the playback and recording panels.

In order to have a workaround for the flatpak applications installed in the **user space**, it's a litle bit more tricky as explained in the related issue.