### PR TITLE
Release 0.4.9

### DIFF
--- a/com.saivert.pwvucontrol.json
+++ b/com.saivert.pwvucontrol.json
@@ -1,12 +1,11 @@
 {
     "app-id": "com.saivert.pwvucontrol",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable",
-        "org.freedesktop.Sdk.Extension.llvm16"
-        
+        "org.freedesktop.Sdk.Extension.llvm18"
     ],
     "command": "pwvucontrol",
     "finish-args": [
@@ -14,11 +13,12 @@
         "--socket=fallback-x11",
         "--device=dri",
         "--socket=wayland",
+        "--socket=pulseaudio",
         "--filesystem=xdg-run/pipewire-0"
     ],
     "build-options": {
-        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm16/bin",
-        "prepend-ld-library-path": "/usr/lib/sdk/llvm16/lib",
+        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm18/lib",
         "env": {
             "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER": "clang",
             "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS": "-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold",
@@ -52,7 +52,7 @@
                 {
                     "type": "git",
                     "tag": "0.4.16",
-                    "url": "https://gitlab.freedesktop.org/pipewire/wireplumber.git"
+                    "url": "https://github.com/PipeWire/wireplumber.git"
                 }
             ]
         },
@@ -66,8 +66,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "sha256": "fc0c89bb6eebd558df7f424a752f7397f57134fac64adb0d7b1c8741a53a8c55",
-                    "url": "https://github.com/saivert/pwvucontrol/releases/download/0.4.8/pwvucontrol-0.4.8.tar.xz"
+                    "sha256": "014de321d1c691585ee12ec65ab2c1571be09f38455ebeece5ad70959b5ae7bd",
+                    "url": "https://github.com/saivert/pwvucontrol/releases/download/0.4.9/pwvucontrol-0.4.9.tar.xz"
                 }
             ]
         }


### PR DESCRIPTION
Let's release 0.4.9.

* Updated Dutch translation by @Vistaus in https://github.com/saivert/pwvucontrol/pull/68
* Add LED peak meter option.
* Add beep on volume change option (only output devices).
* Show product name in port dropdown (e.g. for HDMI ports).
* Fix issue where peak meter is frozen when a stream is paused.

Bump runtime to version 47.
