### PR TITLE
runtime: Update to GNOME 48

### DIFF
--- a/com.saivert.pwvucontrol.json
+++ b/com.saivert.pwvucontrol.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.saivert.pwvucontrol",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable",


### PR DESCRIPTION
New runtime brings altered dark theme and corner radii of Libadwaita 1.7